### PR TITLE
Add hotkeys setup window

### DIFF
--- a/MicStatus.xcodeproj/project.pbxproj
+++ b/MicStatus.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2A3D31E12DF5C8A100F94F8D /* Hotkey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A3D31DF2DF5C8A100F94F8D /* Hotkey.swift */; };
+		2A3D31E22DF5C8A100F94F8D /* HotkeyPreferencesWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A3D31E02DF5C8A100F94F8D /* HotkeyPreferencesWindowController.swift */; };
 		2A6049C82AAA129300C2B381 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A6049C72AAA129300C2B381 /* AppDelegate.swift */; };
 		2A6049CA2AAA129400C2B381 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2A6049C92AAA129400C2B381 /* Assets.xcassets */; };
 		2A6049CD2AAA129400C2B381 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2A6049CB2AAA129400C2B381 /* MainMenu.xib */; };
@@ -14,6 +16,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		2A3D31DF2DF5C8A100F94F8D /* Hotkey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Hotkey.swift; sourceTree = "<group>"; };
+		2A3D31E02DF5C8A100F94F8D /* HotkeyPreferencesWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyPreferencesWindowController.swift; sourceTree = "<group>"; };
 		2A6049C42AAA129300C2B381 /* Mic Status.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Mic Status.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2A6049C72AAA129300C2B381 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		2A6049C92AAA129400C2B381 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -52,6 +56,8 @@
 		2A6049C62AAA129300C2B381 /* MicStatus */ = {
 			isa = PBXGroup;
 			children = (
+				2A3D31DF2DF5C8A100F94F8D /* Hotkey.swift */,
+				2A3D31E02DF5C8A100F94F8D /* HotkeyPreferencesWindowController.swift */,
 				2A6049C72AAA129300C2B381 /* AppDelegate.swift */,
 				2A6049C92AAA129400C2B381 /* Assets.xcassets */,
 				2A6049CB2AAA129400C2B381 /* MainMenu.xib */,
@@ -134,6 +140,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				2A6049C82AAA129300C2B381 /* AppDelegate.swift in Sources */,
+				2A3D31E12DF5C8A100F94F8D /* Hotkey.swift in Sources */,
+				2A3D31E22DF5C8A100F94F8D /* HotkeyPreferencesWindowController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MicStatus/AppDelegate.swift
+++ b/MicStatus/AppDelegate.swift
@@ -129,7 +129,7 @@ end if
             NSEvent.removeMonitor(monitor)
             hotkeyMonitor = nil
         }
-        guard let hotkey = hotkey else { return }
+        guard let hotkey =  else { return }
         hotkeyMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
             let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
             if event.keyCode == hotkey.keyCode && flags.rawValue == hotkey.modifiers {

--- a/MicStatus/Base.lproj/MainMenu.xib
+++ b/MicStatus/Base.lproj/MainMenu.xib
@@ -16,6 +16,7 @@
             <connections>
                 <outlet property="mainMenu" destination="uQy-DD-JDr" id="O0K-cw-IAr"/>
                 <outlet property="monitorMenuAction" destination="qiq-53-DOG" id="z3B-oU-wbz"/>
+                <outlet property="hotkeysMenuAction" destination="vNG-12-Abc" id="abc-de-fgh"/>
                 <outlet property="quitMenuAction" destination="4sb-4s-VLi" id="XiH-a2-oeE"/>
             </connections>
         </customObject>
@@ -26,6 +27,11 @@
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>
                         <action selector="monitoringActionWithMenuItem:" target="Voe-Tx-rLC" id="yBI-Dh-O12"/>
+                    </connections>
+                </menuItem>
+                <menuItem title="Hotkeys..." id="vNG-12-Abc">
+                    <connections>
+                        <action selector="showHotkeys:" target="Voe-Tx-rLC" id="ftQ-wx-k2G"/>
                     </connections>
                 </menuItem>
                 <menuItem title="Quit MicStatus" keyEquivalent="q" id="4sb-4s-VLi">

--- a/MicStatus/Base.lproj/MainMenu.xib
+++ b/MicStatus/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="23727" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22689"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23727"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -14,9 +14,9 @@
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="Mic_Status" customModuleProvider="target">
             <connections>
+                <outlet property="hotkeysMenuAction" destination="vNG-12-Abc" id="abc-de-fgh"/>
                 <outlet property="mainMenu" destination="uQy-DD-JDr" id="O0K-cw-IAr"/>
                 <outlet property="monitorMenuAction" destination="qiq-53-DOG" id="z3B-oU-wbz"/>
-                <outlet property="hotkeysMenuAction" destination="vNG-12-Abc" id="abc-de-fgh"/>
                 <outlet property="quitMenuAction" destination="4sb-4s-VLi" id="XiH-a2-oeE"/>
             </connections>
         </customObject>

--- a/MicStatus/Hotkey.swift
+++ b/MicStatus/Hotkey.swift
@@ -1,0 +1,30 @@
+import Cocoa
+
+struct Hotkey: Codable {
+    let keyCode: UInt16
+    let modifiers: UInt
+    let characters: String
+
+    var displayString: String {
+        var parts: [String] = []
+        let flags = NSEvent.ModifierFlags(rawValue: modifiers)
+        if flags.contains(.command) { parts.append("\u2318") }
+        if flags.contains(.option) { parts.append("\u2325") }
+        if flags.contains(.shift) { parts.append("\u21E7") }
+        if flags.contains(.control) { parts.append("\u2303") }
+        parts.append(characters.uppercased())
+        return parts.joined()
+    }
+
+    static let defaultsKey = "Hotkey"
+
+    static func load() -> Hotkey? {
+        guard let data = UserDefaults.standard.data(forKey: defaultsKey) else { return nil }
+        return try? JSONDecoder().decode(Hotkey.self, from: data)
+    }
+
+    func save() {
+        guard let data = try? JSONEncoder().encode(self) else { return }
+        UserDefaults.standard.set(data, forKey: Hotkey.defaultsKey)
+    }
+}

--- a/MicStatus/Hotkey.swift
+++ b/MicStatus/Hotkey.swift
@@ -8,10 +8,10 @@ struct Hotkey: Codable {
     var displayString: String {
         var parts: [String] = []
         let flags = NSEvent.ModifierFlags(rawValue: modifiers)
-        if flags.contains(.command) { parts.append("\u2318") }
-        if flags.contains(.option) { parts.append("\u2325") }
-        if flags.contains(.shift) { parts.append("\u21E7") }
-        if flags.contains(.control) { parts.append("\u2303") }
+        if flags.contains(.command) { parts.append("\u{2318}") }
+        if flags.contains(.option) { parts.append("\u{2325}") }
+        if flags.contains(.shift) { parts.append("\u{21E7}") }
+        if flags.contains(.control) { parts.append("\u{2303}") }
         parts.append(characters.uppercased())
         return parts.joined()
     }

--- a/MicStatus/HotkeyPreferencesWindowController.swift
+++ b/MicStatus/HotkeyPreferencesWindowController.swift
@@ -1,0 +1,54 @@
+import Cocoa
+
+final class HotkeyPreferencesWindowController: NSWindowController {
+    private let infoLabel = NSTextField(labelWithString: NSLocalizedString("Prefs.Description", comment: ""))
+    private let hotkeyField = NSTextField(string: "")
+    private var monitor: Any?
+
+    init() {
+        let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 300, height: 80),
+                              styleMask: [.titled, .closable],
+                              backing: .buffered, defer: false)
+        window.title = NSLocalizedString("Prefs.Title", comment: "")
+        super.init(window: window)
+        setup()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setup() {
+        guard let content = window?.contentView else { return }
+        infoLabel.frame = NSRect(x: 20, y: 48, width: 260, height: 20)
+        content.addSubview(infoLabel)
+
+        hotkeyField.frame = NSRect(x: 20, y: 20, width: 260, height: 24)
+        hotkeyField.isEditable = false
+        content.addSubview(hotkeyField)
+    }
+
+    override func showWindow(_ sender: Any?) {
+        super.showWindow(sender)
+        hotkeyField.stringValue = Hotkey.load()?.displayString ?? ""
+        if monitor == nil {
+            monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+                guard let self else { return event }
+                let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+                let hotkey = Hotkey(keyCode: event.keyCode,
+                                    modifiers: flags.rawValue,
+                                    characters: event.charactersIgnoringModifiers ?? "")
+                hotkey.save()
+                self.hotkeyField.stringValue = hotkey.displayString
+                (NSApplication.shared.delegate as? AppDelegate)?.updateHotkey(hotkey)
+                return nil
+            }
+        }
+    }
+
+    deinit {
+        if let monitor = monitor {
+            NSEvent.removeMonitor(monitor)
+        }
+    }
+}

--- a/MicStatus/Localizable.xcstrings
+++ b/MicStatus/Localizable.xcstrings
@@ -4,69 +4,50 @@
     "Menu.Quit" : {
       "extractionState" : "manual",
       "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quit MicStatus"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Вийти з MicStatus"
-          }
-        }
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Quit MicStatus" } },
+        "uk" : { "stringUnit" : { "state" : "translated", "value" : "\u0412\u0438\u0439\u0442\u0438 \u0437 MicStatus" } }
       }
     },
     "Menu.Start" : {
       "extractionState" : "manual",
       "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Start Monitoring"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Почати моніторинг"
-          }
-        }
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Start Monitoring" } },
+        "uk" : { "stringUnit" : { "state" : "translated", "value" : "\u041f\u043e\u0447\u0430\u0442\u0438 \u043c\u043e\u043d\u0456\u0442\u043e\u0440\u0438\u043d\u0433" } }
       }
     },
     "Menu.Stop" : {
       "extractionState" : "manual",
       "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stop Monitoring"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Зупинити моніторинг"
-          }
-        }
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Stop Monitoring" } },
+        "uk" : { "stringUnit" : { "state" : "translated", "value" : "\u0417\u0443\u043f\u0438\u043d\u0438\u0442\u0438 \u043c\u043e\u043d\u0456\u0442\u043e\u0440\u0438\u043d\u0433" } }
       }
     },
     "Menu.Title" : {
       "extractionState" : "manual",
       "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "MicStatus"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "MicStatus"
-          }
-        }
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "MicStatus" } },
+        "uk" : { "stringUnit" : { "state" : "translated", "value" : "MicStatus" } }
+      }
+    },
+    "Menu.Hotkeys" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Hotkeys..." } },
+        "uk" : { "stringUnit" : { "state" : "translated", "value" : "\u0413\u0430\u0440\u044f\u0447\u0456 \u043a\u043b\u0430\u0432\u0456\u0448\u0456..." } }
+      }
+    },
+    "Prefs.Title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Hotkey Preferences" } },
+        "uk" : { "stringUnit" : { "state" : "translated", "value" : "\u041d\u0430\u043b\u0430\u0448\u0442\u0443\u0432\u0430\u043d\u043d\u044f \u0433\u0430\u0440\u044f\u0447\u0438\u0445 \u043a\u043b\u0430\u0432\u0456\u0448" } }
+      }
+    },
+    "Prefs.Description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Press keys to set hotkey" } },
+        "uk" : { "stringUnit" : { "state" : "translated", "value" : "\u041d\u0430\u0442\u0438\u0441\u043d\u0456\u0442\u044c \u043a\u043b\u0430\u0432\u0456\u0448\u0456, \u0449\u043e\u0431 \u0432\u0438\u0437\u043d\u0430\u0447\u0438\u0442\u0438 \u043a\u043e\u043c\u0431\u0456\u043d\u0430\u0446\u0456\u044e" } }
       }
     }
   },

--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ To get started with Mic Status, follow these steps:
 ## Usage
 
 - The icon will change to indicate the microphone's status (muted/unmuted).
-- Install [this](https://github.com/raycast/script-commands/blob/master/commands/system/audio/toggle-mic.applescript) apple [script](https://support.apple.com/en-jo/guide/script-editor/scpe037c22c8/mac)
-- Add [hotkey](https://apple.stackexchange.com/questions/175215/how-do-i-assign-a-keyboard-shortcut-to-an-applescript-i-wrote) for new apple script
+- Use the **Hotkeys...** menu item to set a keyboard shortcut for toggling the microphone directly from the app.
 
 ## Development
 


### PR DESCRIPTION
## Summary
- add a simple preferences window to configure a global hotkey
- support global hotkeys in `AppDelegate`
- localize new menu item and preference strings
- document hotkey usage

## Testing
- `swift --version`
- `swiftc MicStatus/AppDelegate.swift MicStatus/Hotkey.swift MicStatus/HotkeyPreferencesWindowController.swift -o /tmp/app` *(fails: no such module 'Cocoa')*

------
https://chatgpt.com/codex/tasks/task_e_6844687cf9a08331a58eac300aaa9e9a