### PR TITLE
Add window delegate cleanup for hotkey preferences

### DIFF
--- a/MicStatus/HotkeyPreferencesWindowController.swift
+++ b/MicStatus/HotkeyPreferencesWindowController.swift
@@ -1,0 +1,18 @@
+import Cocoa
+
+class HotkeyPreferencesWindowController: NSWindowController, NSWindowDelegate {
+    /// Local monitor used to intercept key events while the preferences window is active.
+    var monitor: Any?
+
+    override func windowDidLoad() {
+        super.windowDidLoad()
+        window?.delegate = self
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        if let monitor = monitor {
+            NSEvent.removeMonitor(monitor)
+            self.monitor = nil
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create `HotkeyPreferencesWindowController`
- adopt `NSWindowDelegate`
- remove event monitor when window closes

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684595a2468c833189c22b63bbe8d26c